### PR TITLE
Initial loading

### DIFF
--- a/web/src/components/WidgetView.tsx
+++ b/web/src/components/WidgetView.tsx
@@ -75,7 +75,7 @@ export default function WidgetView(props: Props) {
   }
 
   return (
-    <div className="z-10 h-screen w-full max-w-[1280px] overflow-x-hidden">
+    <div className="z-10 h-full min-h-screen w-full max-w-[1280px] overflow-x-hidden">
       {props.layout.length === 0 ? (
         <div className="flex h-full w-full flex-col items-center justify-center space-y-4 text-foreground">
           <h1 className="text-2xl font-bold">No widgets available.</h1>

--- a/web/src/lib/ui/hooks.ts
+++ b/web/src/lib/ui/hooks.ts
@@ -1,4 +1,4 @@
-import { useIsClient, useWindowSize } from "@uidotdev/usehooks";
+import { useIsClient } from "@uidotdev/usehooks";
 import { useAtom } from "jotai";
 import { useContext, useEffect, useState } from "react";
 import filterWidgetLayoutByRgl from "~/application/layout/filterWidgetLayoutByLayout.service";
@@ -8,12 +8,12 @@ import { type DisplayedWidgets } from "~/server/domain/layout/displayedWidgets";
 import { type RGLayout } from "~/server/domain/layout/layout";
 import { type ScreenSize } from "~/server/domain/other/screenSize";
 import { api } from "../api/api";
-import { BREAKPOINTS } from "../basic/const";
 import Log from "../log/log";
 import type { ToastType } from "../types/types";
 import { CommandContext } from "./context/command";
 import { useBoundStore } from "./state";
 import { toastTextAtom, toastTypeAtom } from "./state/atoms";
+import { getScreenSize } from "./utils";
 
 /**
  * Hook for detecting whether the current screen size is mobile
@@ -34,18 +34,18 @@ export function useDetectMobile() {
  * @returns {ScreenSize} The current screen size
  */
 export function useDetectScreenSize(): ScreenSize {
-  const windowSize = useWindowSize();
-  const [screenSize, setScreenSize] = useState<ScreenSize>("xs");
+  const [screenSize, setScreenSize] = useState<ScreenSize>("xss");
 
   useEffect(() => {
-    if (!windowSize.width) return;
-
-    const size = Object.entries(BREAKPOINTS).findLast(([_key, value]) => {
-      return windowSize.width! >= value;
-    })?.[0] as ScreenSize;
-
-    setScreenSize(size);
-  }, [windowSize]);
+    const windowSize =
+      typeof window === "undefined"
+        ? { width: 0 }
+        : { width: window.innerWidth };
+    if (windowSize.width) {
+      const size = getScreenSize(windowSize.width);
+      setScreenSize(size);
+    }
+  }, []);
 
   return screenSize;
 }

--- a/web/src/lib/ui/utils.ts
+++ b/web/src/lib/ui/utils.ts
@@ -1,0 +1,14 @@
+import { type ScreenSize } from "~/server/domain/other/screenSize";
+import { BREAKPOINTS } from "../basic/const";
+
+/**
+ * Get the screen size based on the width of the screen
+ * @param width Width of the screen
+ * @returns {ScreenSize} The screen size
+ */
+export function getScreenSize(width: number): ScreenSize {
+  const size = Object.entries(BREAKPOINTS).findLast(([_key, value]) => {
+    return width! >= value;
+  })?.[0] as ScreenSize;
+  return size;
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "checkJs": true,
     "skipLibCheck": true,
@@ -18,8 +22,15 @@
     "noUncheckedIndexedAccess": true,
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"]
-    }
+      "~/*": [
+        "./src/*"
+      ]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
   "include": [
     ".eslintrc.cjs",
@@ -27,7 +38,11 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.cjs",
-    "**/*.mjs"
+    "**/*.mjs",
+    ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules", "docs"]
+  "exclude": [
+    "node_modules",
+    "docs"
+  ]
 }


### PR DESCRIPTION
### Issues that were resolved
**1. initially loading shows the widgets in a weird state:**
Sometimes widgets were shown at minimal bounds (1x1) and in edit mode (although editmode was not enabled). This was due to the default screensize value in `useDetectScreenSize`. This issues WAS NOT SOLVED, but rather neglected:
- e.g. using "md" as a default screensize here lead to the issue only appearing on "md" screens.
- "solution": make "xss" the default screensize, because "who will actually use this on xss screens?"

**2. weird console log error message concerning useLayoutEffect:**
There was a log message stating 

> "_Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes._".

 This was likely due to the use of `useWindowSize` in `useDetectScreenSize`.